### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: blacktex
+  name: blacktex
+  description: "Clean up LaTeX files."
+  entry: blacktex
+  language: python
+  language_version: python3
+  types: ['tex']
+  args: [--in-place]


### PR DESCRIPTION
Hi @nschloe, thanks for creating this tool!

I'd like to use this repository as a [pre-commit hook](https://pre-commit.com/), to format changed files on each commit.

According to the developer of pre-commit, tools used with pre-commit should accept multiple files as positional arguments.
- https://github.com/pre-commit/pre-commit/issues/394
- https://github.com/pre-commit/pre-commit/issues/1728

I modified the CLI arguments to support multiple input files when `--in-place` is specified. I tried to ensure that the previous behavior of `[infile] [outfile]` is retained, and added a warning or error that prints to `sys.stderr` whenever invalid combinations of options are provided.

I'm open to your thoughts -- if this is "too breaking" then feel free to reject it and I can just use my fork of the project. I was inspired to do this by another nice TeX tool that has a pre-commit hook: https://github.com/FlamingTempura/bibtex-tidy

Also tagging @s-weigand because I saw they forked this repository and have experience with pre-commit hooks.