### PR TITLE
Another add pre-commit hook PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,21 @@ on:
     - main
 
 jobs:
-  lint:
+  pre-commit:
+    name: Linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.x"
-    - uses: actions/checkout@v2
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        flake8 .
-    - name: Lint with black
-      run: |
-        pip install black
-        black --check .
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.3
 
   build:
+    name: Test
     runs-on: ${{ matrix.os }}
+    needs: [pre-commit]
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,14 @@ jobs:
         black --check .
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
+        include:
+          - python-version: 3.8
+            os: windows-latest
     steps:
     - uses: actions/setup-python@v2
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,3 @@ repos:
     rev: v0.910
     hooks:
       - id: mypy
-
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
-    hooks:
-      - id: setup-cfg-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit
+    rev: v2.13.0
+    hooks:
+      - id: validate_manifest
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/python/black
+    rev: 21.6b0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.17.0
+    hooks:
+      - id: setup-cfg-fmt

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: blacktex
+  name: blacktex
+  description: "Format .tex files with blacktex"
+  entry: blacktex
+  args: [-m, -c]
+  language: python
+  language_version: python3
+  types: [tex]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ You can use
 ```
 blacktex -i in.tex
 ```
-to modify a file in-place. See `blacktex -h` for all options.
+or
+```
+blacktex -m file1.tex file2.tex
+```
+to modify a file/-s in-place. See `blacktex -h` for all options.
 
 ### Installation
 
@@ -48,6 +52,17 @@ blacktex is [available from the Python Package Index](https://pypi.python.org/py
 pip install -U blacktex
 ```
 you can install/upgrade.
+
+### [Pre-commit](https://pre-commit.com/)
+
+Add this to your `.pre-commit-config.yaml`.
+
+```yaml
+  - repo: https://github.com/nschloe/blacktex
+    rev:  ''  # Use the sha / tag /branch you want to point at
+    hooks:
+      - id: blacktex
+```
 
 ### License
 This software is published under the [GPLv3 license](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,10 @@ long_description_content_type = text/markdown
 url = https://github.com/nschloe/blacktex
 author = Nico Schlömer
 author_email = nico.schloemer@gmail.com
-license = GPL-3.0
+license = GPL-3.0-or-later
 license_file = LICENSE
 classifiers =
     Development Status :: 4 - Beta
-    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: OS Independent
     Programming Language :: Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,27 +1,27 @@
 [metadata]
 name = blacktex
 version = 0.4.0
-author = Nico Schlömer
-author_email = nico.schloemer@gmail.com
 description = Cleans up your LaTeX files
-url = https://github.com/nschloe/blacktex
-project_urls =
-    Code=https://github.com/nschloe/blacktex
-    Issues=https://github.com/nschloe/blacktex/issues
-    Funding=https://github.com/sponsors/nschloe
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = GPL-3.0-or-later
+url = https://github.com/nschloe/blacktex
+author = Nico Schlömer
+author_email = nico.schloemer@gmail.com
+license = GPL-3.0
+license_file = LICENSE
 classifiers =
     Development Status :: 4 - Beta
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
     Topic :: Text Editors :: Text Processing
     Topic :: Text Processing
     Topic :: Text Processing :: Markup
@@ -30,6 +30,10 @@ classifiers =
 keywords =
     latex
     linting
+project_urls =
+    Code=https://github.com/nschloe/blacktex
+    Issues=https://github.com/nschloe/blacktex/issues
+    Funding=https://github.com/sponsors/nschloe
 
 [options]
 package_dir =

--- a/src/blacktex/__about__.py
+++ b/src/blacktex/__about__.py
@@ -2,7 +2,7 @@ try:
     # Python 3.8
     from importlib import metadata
 except ImportError:
-    import importlib_metadata as metadata
+    import importlib_metadata as metadata  # type: ignore
 
 try:
     __version__ = metadata.version("blacktex")

--- a/src/blacktex/__init__.py
+++ b/src/blacktex/__init__.py
@@ -1,5 +1,5 @@
 from . import cli
 from .__about__ import __version__
-from .main import clean
+from .main import clean, process_file
 
-__all__ = ["__version__", "cli", "clean"]
+__all__ = ["__version__", "cli", "clean", "process_file"]

--- a/src/blacktex/cli.py
+++ b/src/blacktex/cli.py
@@ -33,6 +33,7 @@ def main(argv=None):
         args.in_place,
         args.keep_comments,
         args.keep_dollar_math,
+        args.encoding,
     )
 
     return int(any(return_values))
@@ -63,6 +64,14 @@ def _get_parser():
         type=argparse.FileType("r"),
         default=[],
         help="list of files to process (needs '-m' flag)",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--encoding",
+        type=str,
+        default=None,
+        help="encoding to use for reading and writing files",
     )
 
     parser.add_argument(

--- a/src/blacktex/main.py
+++ b/src/blacktex/main.py
@@ -376,6 +376,8 @@ def process_file(
     in_place=False,
     keep_comments=False,
     keep_dollar=False,
+    encoding=None,
+    *,
     return_values=[],
 ) -> List[int]:
     if isinstance(infile, list):
@@ -383,22 +385,23 @@ def process_file(
             if infile is not sys.stdin and infile is not sys.stdout:
                 process_file(infile, outfile, True, keep_comments, keep_dollar)
     else:
-        # needed for multiple file mode since outfile is opened in a+ mode
-        if infile is not sys.stdin:
-            infile.seek(0)
-        content = infile.read()
+        if infile is sys.stdin:
+            content = infile.read()
+        else:
+            with open(infile.name, "r", encoding=encoding) as f:
+                content = f.read()
 
         out = clean(content, keep_comments, keep_dollar)
 
         if in_place:
             if content != out:
-                with open(infile.name, "w") as f:
+                with open(infile.name, "w", encoding=encoding) as f:
                     f.write(out)
-        else:
-            if outfile is not sys.stdout:
-                outfile.seek(0)
-                outfile.truncate()
+        elif outfile is sys.stdout:
             outfile.write(out)
+        else:
+            with open(outfile.name, "w", encoding=encoding) as f:
+                f.write(out)
 
         if content != out and (in_place or outfile is not sys.stdout):
             return_values.append(1)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,19 +1,103 @@
-import tempfile
+import io
 from pathlib import Path
+from typing import List
+
+import pytest
+from _pytest.capture import CaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
 
 import blacktex
 
 
-def test_cli():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
-        infile = tmpdir / "in.tex"
-        outfile = tmpdir / "out.tex"
-        with open(infile, "w") as f:
-            f.write("a+b=c")
+@pytest.fixture()
+def infiles(tmp_path: Path):
+    tmp_files = [tmp_path / f"infile_{i}.tex" for i in range(1, 4)]
+    [tmp_file.write_text(f"{tmp_file.name}\na+b=c") for tmp_file in tmp_files]
+    yield tmp_files
 
-        blacktex.cli.main([str(infile), str(outfile)])
 
-        with open(outfile) as f:
-            line = f.read()
-            assert line == "a+b = c"
+def test_cli_stdin(monkeypatch: MonkeyPatch, capsys: CaptureFixture):
+    monkeypatch.setattr("sys.stdin", io.StringIO("stdin\na+b = c"))
+    return_value = blacktex.cli.main([])
+
+    sdtout, _ = capsys.readouterr()
+
+    assert return_value == 0
+    assert sdtout == "stdin\na+b = c"
+
+
+def test_cli_stdout(infiles: List[Path], capsys: CaptureFixture):
+    infile = infiles[0]
+
+    return_value = blacktex.cli.main([str(infile)])
+
+    sdtout, _ = capsys.readouterr()
+
+    assert return_value == 0
+    assert sdtout == "infile_1.tex\na+b = c"
+    assert infile.read_text() == "infile_1.tex\na+b=c"
+
+
+def test_cli_inplace(infiles: List[Path]):
+    infile = infiles[0]
+
+    return_value = blacktex.cli.main(["-i", str(infile)])
+
+    assert return_value == 1
+    assert infile.read_text() == "infile_1.tex\na+b = c"
+
+
+def test_cli_outfile(infiles: List[Path], tmp_path: Path):
+    infile = infiles[0]
+    out_file = tmp_path / "out.tex"
+
+    assert not out_file.exists()
+
+    return_value = blacktex.cli.main([str(infile), str(out_file)])
+
+    assert return_value == 1
+    assert out_file.exists()
+    assert out_file.read_text() == "infile_1.tex\na+b = c"
+
+
+def test_cli_existing_outfile(infiles: List[Path], tmp_path: Path):
+    infile = infiles[0]
+    out_file = tmp_path / "out.tex"
+    out_file.write_text("foo bar")
+
+    assert out_file.exists()
+
+    return_value = blacktex.cli.main([str(infile), str(out_file)])
+
+    assert return_value == 1
+    assert out_file.exists()
+    assert out_file.read_text() == "infile_1.tex\na+b = c"
+
+
+def test_cli_multiple_files_no_flag(infiles: List[Path], capsys: CaptureFixture):
+    return_value = blacktex.cli.main([str(infile) for infile in infiles])
+
+    _, stderr = capsys.readouterr()
+
+    assert return_value == 1
+    assert stderr == "Too many files, the '-m' needs to be set to use multiple files.\n"
+    for infile in infiles:
+        assert infile.read_text() == f"{infile.name}\na+b=c"
+
+
+def test_cli_multiple_files_flag_stdin(infiles: List[Path], capsys: CaptureFixture):
+
+    return_value = blacktex.cli.main(["-m"])
+
+    _, stderr = capsys.readouterr()
+
+    assert return_value == 1
+    assert stderr == "Too few files, multiple file mode needs at least one file.\n"
+
+
+def test_cli_multiple_files(infiles: List[Path]):
+    return_value = blacktex.cli.main(["-m", *[str(infile) for infile in infiles]])
+
+    assert return_value == 1
+    for infile in infiles:
+        assert infile.read_text() == f"{infile.name}\na+b = c"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -38,6 +38,17 @@ def test_cli_stdout(infiles: List[Path], capsys: CaptureFixture):
     assert infile.read_text() == "infile_1.tex\na+b=c"
 
 
+def test_cli_encoding(tmp_path: Path):
+    infile = tmp_path / "infile_encoding.tex"
+    result = "äöüéкий的"
+    infile.write_text(result, encoding="utf8")
+
+    return_value = blacktex.cli.main(["-i", "-e=utf8", str(infile)])
+
+    assert return_value == 0
+    assert infile.read_text(encoding="utf8") == result
+
+
 def test_cli_inplace(infiles: List[Path]):
     infile = infiles[0]
 


### PR DESCRIPTION
Hi @nschloe also thanks for the tool

This PR wants to achieve the same as #33, but keeping it backward compatible.

## Changelist
- Added pre-commit-hook
- Added `-m`/`--allow-multiple-files` flag to allow `in-place` formatting of multiple files
- Added `-e`/`--encoding` option (especially needed for windows where python uses codepages as encoding, this why there is a Windows CI job now)
- Extended CLI tests
- Added pre-commit config with some QA tools
- Changed CI linting job to use pre-commit and run all tools at once